### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 BINDIR=/usr/bin
 MAN8DIR=/usr/share/man/man8
+INSTALL=install
 
 Zzz:  Zzz.c
 	cc -o Zzz Zzz.c -framework IOKit
 
 install: Zzz
-	install -c -m 511 Zzz $(BINDIR)
-	install -c -m 644 Zzz.8 $(MAN8DIR)
+	$(INSTALL) -c -m 511 Zzz $(BINDIR)
+	$(INSTALL) -c -m 644 Zzz.8 $(MAN8DIR)

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,6 @@ Zzz:  Zzz.c
 	cc -o Zzz Zzz.c -framework IOKit
 
 install: Zzz
+	$(INSTALL) -d $(BINDIR) $(MAN8DIR)
 	$(INSTALL) -c -m 511 Zzz $(BINDIR)
 	$(INSTALL) -c -m 644 Zzz.8 $(MAN8DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-BINDIR=/usr/bin
-MAN8DIR=/usr/share/man/man8
+PREFIX=/usr
+BINDIR=$(DESTDIR)$(PREFIX)/bin
+MAN8DIR=$(DESTDIR)$(PREFIX)/share/man/man8
 INSTALL=install
 
 Zzz:  Zzz.c

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINDIR=/usr/bin
 MAN8DIR=/usr/share/man/man8
 
 Zzz:  Zzz.c
-	cc -o Zzz Zzz.c -lIOKit
+	cc -o Zzz Zzz.c -framework IOKit
 
 install: Zzz
 	install -c -m 511 Zzz $(BINDIR)


### PR DESCRIPTION
* Use `-framework IOKit` instead of `-lIOKit` when building
* Allow the `install` program to be configured
* Create directories before installing files; otherwise Zzz will fail to install to a `BINDIR`/`MAN8DIR` that doesn't currently exist
* Allow `PREFIX` and `DESTDIR` to be passed, in which case `BINDIR` and `MAN8DIR` will be relative to that prefix