### PR TITLE
fix: update main function signature to conform to ISO C99 standard

### DIFF
--- a/Zzz.c
+++ b/Zzz.c
@@ -18,19 +18,17 @@ fail(char *why)
     exit(1);
 }
 
-int
-main(argc, argv)
-char **argv;
+int main(int argc, char **argv)
 {
     mach_port_t kernel;
     io_connect_t controller;
 
     if ( IOMasterPort(bootstrap_port, &kernel) != kIOReturnSuccess )
 	fail("Can't find the kernel port");
-    
+
     if ( (controller=IOPMFindPowerManagement(kernel)) == 0 )
 	fail("Can't find the power management port");
-    
+
     if ( IOPMSleepSystem(controller) != kIOReturnSuccess )
 	fail("The sleep request failed");
 


### PR DESCRIPTION
seeing the build failure in https://github.com/Homebrew/homebrew-core/actions/runs/10812356879/job/29993858551#step:4:61

```
  cc -o Zzz Zzz.c -framework IOKit
  Zzz.c:22:6: error: parameter 'argc' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     22 | main(argc, argv)
        |      ^
     23 | char **argv;
     24 | {
  1 error generated.
```